### PR TITLE
upgrading resolve-url-loader to version 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22433,7 +22433,7 @@
         "react-dev-utils": "^12.0.1",
         "react-refresh": "^0.11.0",
         "resolve": "^1.20.0",
-        "resolve-url-loader": "^4.0.0",
+        "resolve-url-loader": "^5.0.0",
         "sass-loader": "^12.3.0",
         "semver": "^7.3.5",
         "source-map-loader": "^3.0.0",
@@ -23468,57 +23468,24 @@
       "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "node_modules/resolve-url-loader": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-4.0.0.tgz",
-      "integrity": "sha512-05VEMczVREcbtT7Bz+C+96eUO5HDNvdthIiMB34t7FcF8ehcu4wC0sSgPUubs3XW2Q3CNLJk/BJrCU9wVRymiA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
+      "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
       "dependencies": {
         "adjust-sourcemap-loader": "^4.0.0",
         "convert-source-map": "^1.7.0",
         "loader-utils": "^2.0.0",
-        "postcss": "^7.0.35",
+        "postcss": "^8.2.14",
         "source-map": "0.6.1"
       },
       "engines": {
-        "node": ">=8.9"
-      },
-      "peerDependencies": {
-        "rework": "1.0.1",
-        "rework-visit": "1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rework": {
-          "optional": true
-        },
-        "rework-visit": {
-          "optional": true
-        }
+        "node": ">=12"
       }
     },
     "node_modules/resolve-url-loader/node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
-    },
-    "node_modules/resolve-url-loader/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
-    },
-    "node_modules/resolve-url-loader/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
     },
     "node_modules/resolve-url-loader/node_modules/source-map": {
       "version": "0.6.1",


### PR DESCRIPTION
Closes # (if applicable).

It **partially** addresses issue https://github.com/open-energy-transition/handbook/issues/36

## Changes Proposed in This Pull Request

This pull request upgrades the resolve-url-loader to version 5.0.0

## Checklist

- [x] I tested my contribution locally, and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] If new pages are added, maintainers are assigned for that document.
- [ ] If the document falls under a controlled category, a controlled document banner is present.
