### PR TITLE
Minor changes to the 'About the OET product' & the 'Data analysis and validation' sections

### DIFF
--- a/docs/Product/AboutTheOETProduct.mdx
+++ b/docs/Product/AboutTheOETProduct.mdx
@@ -12,7 +12,7 @@ import ControlledDocBanner from "@site/src/components/ControlledDocBanner";
 
 <ControlledDocBanner />
 
-Open Energy Transition (OET) continues to build on open source software. PyPSA project, initially started in Academia, back in 2016, is being developed actively.
+Open Energy Transition (OET) continues to build on open source software. PyPSA project, initially started in Academia, back in 2015, is being developed actively.
 
 As of now, the PyPSA engine counts approx. 25,000 lines of Python code.
 

--- a/docs/Product/AboutTheOETProduct.mdx
+++ b/docs/Product/AboutTheOETProduct.mdx
@@ -12,7 +12,7 @@ import ControlledDocBanner from "@site/src/components/ControlledDocBanner";
 
 <ControlledDocBanner />
 
-Open Energy Transition continues to build on open source software. PyPSA project, initially started in Academia, back in 2016, is being developed actively.
+Open Energy Transition (OET) continues to build on open source software. PyPSA project, initially started in Academia, back in 2016, is being developed actively.
 
 As of now, the PyPSA engine counts approx. 25,000 lines of Python code.
 
@@ -20,13 +20,12 @@ As of now, the PyPSA engine counts approx. 25,000 lines of Python code.
 
 Open Energy Transition actively uses, and extends PyPSA, for the purposes of studies, consultations, workshops, presentations, conferences and projects.
 
+- PyPSA modules are further improved, as required by the the aforementioned projects/studies and the consultation services, being conducted in different geographical areas.
 - Any such modifications are backfed upstream, to the original PyPSA-X repository.
 
 The code gets reviewed and modified by dozens of associates/contributors in power systems planning, operation and energy economics.
 
-PyPSA modules are further improved, as needed, for the purposes of the projects being conducted in the different geographical areas, and the aforementioned consultation services.
-
-All of the available code regarding Open Energy Transition and PyPSA is free for use, as well as further modifications. The modifications can be submitted upstream to GitHub, using GitHub Fork -> Pull Request. Upon the review, the code maintainer acts on the basis of proposed code change:
+The publicly available OET and PyPSA code is free for use, as well as further modifications. The modifications can be submitted to the GitHub upstream repositories, using GitHub Fork -> Pull Request. Upon the review, the code maintainer acts on the basis of proposed code change:
 - accepts the change,
 - comments on the change,
 - rejects the change, providing a reason.

--- a/docs/Product/DataAnalysisValidation.mdx
+++ b/docs/Product/DataAnalysisValidation.mdx
@@ -13,17 +13,17 @@ import ControlledDocBanner from "@site/src/components/ControlledDocBanner";
 
 ## Data analysis
 
-Data analysis performed by us revolves around gathering the data, required for modeling the power systems, in various aspects.
+Data analysis, performed by us, revolves around the data gathering, required for modeling the power systems from different perspectives:
 
-- It is both the technical and the market data, used as the backbone for the power system expansion, unit commitment/economic dispatch, and the power flow simulation.
-- Data analysis has a crucial role, prior the computer simulation, as the correct input data is the foundation of the work that follows.
+- it is both the technical and the economic data, used as the backbone for the unit commitment/economic dispatch, the power flow simulation, as well as the power system expansion,
+- data analysis has a crucial role, prior the power system's simulation, as the correct input data is the foundation of the work that follows.
 
 ## Data validation
 
-The way to go around inspecting the validity of the input data is by examining the historically recorded results, against the output results. It is a known [backcasting](https://www.semcommittee.com/publications/sem-21-086-sem-plexos-model-validation-2021-2029-and-backcast-report), the standard used by the industry.
+The way to go around inspecting the validity of the input data is by examining the historically recorded results, against the model's output results. It is a well known [backcasting](https://www.semcommittee.com/publications/sem-21-086-sem-plexos-model-validation-2021-2029-and-backcast-report) process, the standard used across the industry.
 
 _It operates on the principle of the feedback loop, where the input data is tuned, until the output matches the recorded historical values, to the best of ability, rendering the input data valid._
 
-`Backcast` complements the `forecast`, considering the focus of the former is placed on identifying the correct input, to be used for the further calculation.
+`Backcast` complements the `forecast`, considering the focus of the former is placed on identifying the correct input, to be used for the further calculation, i.e. the forecast.
 
 _That said, a successful backcast precedes every forecast, providing validity to the entire process._

--- a/docs/Product/ProductPrinciples.mdx
+++ b/docs/Product/ProductPrinciples.mdx
@@ -12,7 +12,7 @@ import ControlledDocBanner from "@site/src/components/ControlledDocBanner";
 
 <ControlledDocBanner />
 
-Open Energy Transition continues to build on open software, initially started in Academia, back in 2016. As of now, the PyPSA project has  more than 100,000 lines of Python code.
+Open Energy Transition continues to build on open software, initially started in Academia, back in 2015. As of now, the PyPSA project has  more than 100,000 lines of Python code.
 
 The code gets reviewed & modified by dozens of associates/contributors in power systems planning, operation & energy economics.
 


### PR DESCRIPTION
Again there was an issue with the **package-lock.json** & **package.json** for some reason, and I had to manually `git restore` them to avoid their updates in the feature branch.

For some reason they are simply not ignored, in accordance with the <mark>.gitignore</mark> file.

Modified 2016 to 2015 as the commencing year of PyPSA, in both the "Product principles" & "About the OET product."