### PR TITLE
Make CI build required before merging PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@ Closes # (if applicable).
 
 ## Checklist
 
+- [ ] I have checked the Deploy Preview link in the netlify bot's comment, and my changes look good
 - [ ] I tested my contribution locally, and it seems to work fine.
 - [ ] Code and workflow changes are sufficiently documented.
 - [ ] If new pages are added, maintainers are assigned for that document.

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,6 +25,7 @@ defaults:
 
 jobs:
   build:
+    name: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docs/Company/WelcomeToOET.mdx
+++ b/docs/Company/WelcomeToOET.mdx
@@ -84,7 +84,7 @@ Things to Do and Remember:
 
 ## 7. Other administrative tools
 ### Remote.com
-**Remote.com**, our partner Employer of Record, is used for employment-related processes, such as contract management, payroll, and absence requests. Please continually ensure that your profile is up-to-date, and reach out to Quintin if you have any questions. You can also contact Remote directly, via [their general email]{mailto:help@remote.com}, and they will direct your query to the relevant department. If you want, you can CC Quintin into the intiial email so he is kept in comms.
+**Remote.com**, our partner Employer of Record, is used for employment-related processes, such as contract management, payroll, and absence requests. Please continually ensure that your profile is up-to-date, and reach out to Quintin if you have any questions. You can also contact Remote directly, via [their general email](mailto:help@remote.com), and they will direct your query to the relevant department. If you want, you can CC Quintin into the intiial email so he is kept in comms.
 [Link to Remote.com](https://remote.com/)
 
 ### Navan

--- a/docs/Company/WelcomeToOET.mdx
+++ b/docs/Company/WelcomeToOET.mdx
@@ -50,7 +50,7 @@ On your first day, please make sure you go to the [#welcome channel](https://dis
 We will also welcome you during the first weekly all-hands meeting you attend (wherein we'll ask you to introduce yourself, and share any fun info about yourself that you'd like to). If you don't already have an invitation for that meeting (which takes place on Tuesdays), please request one from Quintin.
 
 ### Prio talk thread
-Everyone has a "prio talk" thread in the Discussion channel that must please be updated every Monday (for the purpose of broad organizatijonal oversight and planning by Senior Leadership) with:
+Everyone has a "prio talk" thread in the Discussion channel that must please be updated every Monday (for the purpose of broad organizational oversight and planning by Senior Leadership) with:
 - A list of upcoming tasks in priority order.
 - Ongoing updates (by moving tasks from "Doing" to "Done)."
 - A "Backlog" or "Ideas" section (ideally separated and pinned to the thread) if you have things that may be done in future.
@@ -84,7 +84,7 @@ Things to Do and Remember:
 
 ## 7. Other administrative tools
 ### Remote.com
-**Remote.com**, our partner Employer of Record, is used for employment-related processes, such as contract management, payroll, and absence requests. Please continually ensure that your profile is up-to-date, and reach out to Quintin if you have any questions. You can also contact Remote directly, via [their general email](mailto:help@remote.com), and they will direct your query to the relevant department. If you want, you can CC Quintin into the intiial email so he is kept in comms.
+**Remote.com**, our partner Employer of Record, is used for employment-related processes, such as contract management, payroll, and absence requests. Please continually ensure that your profile is up-to-date, and reach out to Quintin if you have any questions. You can also contact Remote directly, via [their general email](mailto:help@remote.com), and they will direct your query to the relevant department. If you want, you can CC Quintin into the initial email so he is kept in comms.
 [Link to Remote.com](https://remote.com/)
 
 ### Navan


### PR DESCRIPTION
Closes # (if applicable).

## Changes Proposed in This Pull Request

Trying to ensure that PRs can only be merged in if the website builds successfully. See https://stackoverflow.com/a/68613319/3189420

## Checklist

- [ ] I tested my contribution locally, and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] If new pages are added, maintainers are assigned for that document.
- [ ] If the document falls under a controlled category, a controlled document banner is present.
