### PR TITLE
Update handbook references to person when offboarding

### DIFF
--- a/docs/Company/WelcomeToOET.mdx
+++ b/docs/Company/WelcomeToOET.mdx
@@ -40,7 +40,7 @@ Project folder access is granted as needed. To request access, contact the relev
 - [Weekly all-company meetings](https://drive.google.com/drive/folders/1tWOjM8sdctOdTkoF7Vp7w6QZZnCTCR0y?usp=sharing): has minutes and presentations of internal meetings, such as the weekly Tuesday meeting and knowledge-sharing sessions
 
 ## 3. Everyday communications: Discord
-**Discord** is important for more than just meetings — it’s a central hub for our internal communication. Please take a look at the [Discord](RemoteWorking#discord) section of our [Remote Working](docs/Company/RemoteWorking) page to see how we use Discord to communicate, and stay updated on team discussions, project statuses, and any announcements.
+**Discord** is important for more than just meetings — it’s a central hub for our internal communication. Please take a look at the [Discord](RemoteWorking#discord) section of our [Remote Working](RemoteWorking) page to see how we use Discord to communicate, and stay updated on team discussions, project statuses, and any announcements.
 
 Using Discord instead of Teams can be quite a change for many!
 If you’re new to the platform, it would be a great idea to watch a [tutorial video](https://www.youtube.com/watch?v=z5c6Bc-S0TI). You should have received an invitation to join the OET Discord channel in your welcome email. If you did not, please reach out to whoever you have been liaising with to request that they share the link. We use the OET Discord channel for most internal communications. It’s a versatile platform with spaces for text and voice communication, and it’s where we encourage you to:

--- a/docs/People/Offboarding.mdx
+++ b/docs/People/Offboarding.mdx
@@ -24,6 +24,7 @@ The manager of the person leaving OET must ensure that by the end of their last 
 - Any special requests for the transfer of cloud storage to the manager have been sent to our Head of People
 - A pull request has been created to remove the person's photo and info from the [OET Data Bank](https://github.com/orgs/open-energy-transition/people)
 - The person's solver license keys are deactivated (ask Sid Krishna if you need support with this)
+- All references to the person in this handbook are updated to the person taking over that responsibility
 
 Our People Team will:
 - Remove access to platforms only once the final workday has ended


### PR DESCRIPTION
## Changes Proposed in This Pull Request

Adds an offboarding item to update all references in the handbook to the person leaving.

## Checklist

- [ ] I have checked the Deploy Preview link in the netlify bot's comment, and my changes look good
- [x] I tested my contribution locally, and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] If new pages are added, maintainers are assigned for that document.
- [x] If the document falls under a controlled category, a controlled document banner is present.
