### PR TITLE
fix: security trainings link

### DIFF
--- a/docs/Security/SecureSoftwareDevelopment.mdx
+++ b/docs/Security/SecureSoftwareDevelopment.mdx
@@ -155,7 +155,7 @@ To meet ISO requirements, OET employees should complete training that matches th
 
 | Category | Recommended Course / Resource |
 | :--- | :--- |
-| **Open Models & Public Dashboards** | [GitHub Skills: Maintain a Secure Repo](https://learn.microsoft.com/en-us/training/modules/maintain-secure-repository-github/) (35 mins) + OET Secrets Checklist. |
+| **Open Models & Public Dashboards** | [GitHub Skills: Maintain a Secure Repo](https://learn.microsoft.com/en-us/training/modules/maintain-secure-repository-github/) (35 mins) + [OET Security Best Practices](/docs/Engineering/CodingGuidelines#security-best-practices). |
 | **Open Tools (Libraries)** | The above + [Snyk Learn: OWASP Top 10 for OSS](https://learn.snyk.io/learning-paths/owasp-top-10-open-source-software-risks/) (2.5 hrs). |
 | **Products & Platforms** | The above + **[OpenSSF LFD121](https://training.linuxfoundation.org/training/developing-secure-software-lfd121/)** (Full course) + [Hacksplaining](https://www.hacksplaining.com/lessons) for Web Vulnerabilities. |
 


### PR DESCRIPTION
The ambiguous reference to "OET Secrets Checklist" didn't match anything in the Handbook. Updated it to concrete reference to existing security best practices.

Closes # (if applicable).

## Changes Proposed in This Pull Request

## Checklist

- [x] I have checked the Deploy Preview link in the netlify bot's comment, and my changes look good
- [x] I tested my contribution locally, and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] If new pages are added, maintainers are assigned for that document.
- [x] If the document falls under a controlled category, a controlled document banner is present.
