### PR TITLE
Add DPO role to Incident Management documentation

### DIFF
--- a/docs/Security/IncidentManagement.mdx
+++ b/docs/Security/IncidentManagement.mdx
@@ -29,6 +29,7 @@ The following roles are responsible for managing security incidents:
 | **Information Security Manager (ISM)** | Coordinates the overall incident management process, including classification, escalation, and reporting to management. They assign an Incident Coordinator and will inform the Information Security Officer (ISO) about the incident. |
 | **Incident Coordinator** | Nominated by the ISM depending on the type and domain of the incident. Manages specific containment, resolution, and recovery activities; acts as the primary point of contact during an incident. |
 | **Incident Response Team (IRT)** | Technical and administrative staff who support investigation, documentation, and mitigation. |
+| **Data Protection Officer (DPO)** | Supports the assessment and handling of incidents involving personal data, including evaluation of regulatory notification obligations and communication with supervisory authorities where required |
 | **OET Management** | Heads of Departments and CEO. Responsible for final decision-making during major incidents and allocating necessary resources for recovery. |
 
 As of March 2026, our ISM is [Stefan Radnev](mailto:stefan.radnev@openenergytransition.org) and our ISO is [Bartosz Naumowicz](mailto:bartosz.naumowicz@openenergytransition.org). Permanent members of the IRT include the Heads of People and Software; others are added to the team depending on the incident.


### PR DESCRIPTION
Added Data Protection Officer (DPO) role and responsibilities to the incident management documentation.

Closes # (if applicable).

## Changes Proposed in This Pull Request

## Checklist

- [x] I have checked the Deploy Preview link in the netlify bot's comment, and my changes look good
- [ ] I tested my contribution locally, and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] If new pages are added, maintainers are assigned for that document.
- [x] If the document falls under a controlled category, a controlled document banner is present.
